### PR TITLE
Allow reaper to reap all outstanding workers before a provision event

### DIFF
--- a/pancancer-arch-3/src/main/java/info/pancancer/arch3/containerProvisioner/ContainerProvisionerThreads.java
+++ b/pancancer-arch-3/src/main/java/info/pancancer/arch3/containerProvisioner/ContainerProvisionerThreads.java
@@ -47,6 +47,8 @@ public class ContainerProvisionerThreads extends Base {
 
     private static final int DEFAULT_THREADS = 3;
     private static final int MINUTE_IN_MILLISECONDS = 60 * 1000;
+    private static final int TWO_MINUTE_IN_MILLISECONDS = 2 * 60 * 1000;
+
     private final OptionSpecBuilder testSpec;
     protected static final Logger LOG = LoggerFactory.getLogger(ContainerProvisionerThreads.class);
 
@@ -235,7 +237,8 @@ public class ContainerProvisionerThreads extends Base {
                             }
                         }
                         if (endless) {
-                            Thread.sleep(MINUTE_IN_MILLISECONDS);
+			    // lengthen time to allow cleanup queue to purge
+                            Thread.sleep(TWO_MINUTE_IN_MILLISECONDS);
                         }
                     }
                 } while (endless);

--- a/pancancer-arch-3/src/main/java/info/pancancer/arch3/containerProvisioner/ContainerProvisionerThreads.java
+++ b/pancancer-arch-3/src/main/java/info/pancancer/arch3/containerProvisioner/ContainerProvisionerThreads.java
@@ -317,9 +317,6 @@ public class ContainerProvisionerThreads extends Base {
                             synchronized (ContainerProvisionerThreads.class) {
                                 runReaper(settings, status.getIpAddress(), status.getVmUuid());
                             }
-                            if (endless) {
-                                Thread.sleep(MINUTE_IN_MILLISECONDS);
-                            }
                         } else if (status.getState() == StatusState.RUNNING || status.getState() == StatusState.FAILED
                                 || status.getState() == StatusState.PENDING || status.getState() == StatusState.PROVISIONING) {
                             // deal with running, failed, pending, provisioning


### PR DESCRIPTION
Not sure why this pause was in here, probably pointless consistency
