### PR TITLE
Feature/solomon consistent log paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
 
 script: 
   - mvn -B clean install -DskipITs=false
-  - mvn -B clean -DskipITs=false cobertura:cobertura cobertura:cobertura-integration-test coveralls:report
+  - mvn -B clean -DskipITs=false -DFULL_LOGGING_PATH=/var/log/arch3/arch3_test.log cobertura:cobertura cobertura:cobertura-integration-test coveralls:report
 
 addons:
   postgresql: "9.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
 
 script: 
   - mvn -B clean install -DskipITs=false
-  - mvn -B clean -DskipITs=false -DCONSONANCE_LOG_FILE=./arch3_test.log cobertura:cobertura cobertura:cobertura-integration-test coveralls:report
+  - mvn -B clean -DskipITs=false  cobertura:cobertura cobertura:cobertura-integration-test coveralls:report
 
 addons:
   postgresql: "9.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
 
 script: 
   - mvn -B clean install -DskipITs=false
-  - mvn -B clean -DskipITs=false -DFULL_LOGGING_PATH=/var/log/arch3/arch3_test.log cobertura:cobertura cobertura:cobertura-integration-test coveralls:report
+  - mvn -B clean -DskipITs=false -DCONSONANCE_LOG_FILE=./arch3_test.log cobertura:cobertura cobertura:cobertura-integration-test coveralls:report
 
 addons:
   postgresql: "9.3"

--- a/pancancer-arch-3/pom.xml
+++ b/pancancer-arch-3/pom.xml
@@ -271,6 +271,15 @@
                     <target>1.7</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <CONSONANCE_LOG_FILE>./test.log</CONSONANCE_LOG_FILE>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/pancancer-arch-3/pom.xml
+++ b/pancancer-arch-3/pom.xml
@@ -280,6 +280,15 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <CONSONANCE_LOG_FILE>./test.log</CONSONANCE_LOG_FILE>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/pancancer-arch-3/src/main/java/info/pancancer/arch3/jobGenerator/JobGenerator.java
+++ b/pancancer-arch-3/src/main/java/info/pancancer/arch3/jobGenerator/JobGenerator.java
@@ -164,7 +164,7 @@ public class JobGenerator extends Base {
         String[] arr = this.settings.getStringArray(Constants.JOB_GENERATOR_FILTER_KEYS_IN_HASH);
         Map<String, String> filteredIniFileEntries = iniFileEntries;
         if (arr.length > 0) {
-            System.out.println("Using ini hash filter set: " + Arrays.toString(arr));
+            log.info("Using ini hash filter set: " + Arrays.toString(arr));
             Set<String> keys = new HashSet<>();
             Map<String, String> filteredMap = new LinkedHashMap<>();
             keys.addAll(Arrays.asList(arr));
@@ -183,9 +183,9 @@ public class JobGenerator extends Base {
             boolean runPreviously = db.previouslyRun(hashStr);
             if (runPreviously) {
                 if (this.options.has(this.forceSpec)) {
-                    System.out.println("Forcing scheduling, but would have skipped file (null if testing) due to hash: " + file);
+                    log.info("Forcing scheduling, but would have skipped file (null if testing) due to hash: " + file);
                 } else {
-                    System.out.println("Skipping file (null if testing) due to hash: " + file);
+                    log.info("Skipping file (null if testing) due to hash: " + file);
                     return null;
 
                 }

--- a/pancancer-arch-3/src/test/resources/logback-test.xml
+++ b/pancancer-arch-3/src/test/resources/logback-test.xml
@@ -3,10 +3,10 @@
     <appender name="FILE_APPENDER" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <!-- encoders are assigned the type
         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
-        <file>${FULL_LOGGING_PATH}</file>
+        <file>${CONSONANCE_LOG_FILE}</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <maxHistory>5</maxHistory>
-            <fileNamePattern>${FULL_LOGGING_PATH}.%d{YYYY-MM-dd}.%i.zip</fileNamePattern>
+            <fileNamePattern>${CONSONANCE_LOG_FILE}.%d{YYYY-MM-dd}.%i.zip</fileNamePattern>
             <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                 <maxFileSize>2GB</maxFileSize>
             </timeBasedFileNamingAndTriggeringPolicy>

--- a/pancancer-arch-3/src/test/resources/logback-test.xml
+++ b/pancancer-arch-3/src/test/resources/logback-test.xml
@@ -3,7 +3,7 @@
     <appender name="FILE_APPENDER" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <!-- encoders are assigned the type
         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
-        <file>./arch3_test.log</file>
+        <file>${FULL_LOGGING_PATH}</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <maxHistory>5</maxHistory>
             <fileNamePattern>./arch3_old/arch3_test.%d{YYYY-MM-dd}.%i.log.zip</fileNamePattern>

--- a/pancancer-arch-3/src/test/resources/logback-test.xml
+++ b/pancancer-arch-3/src/test/resources/logback-test.xml
@@ -6,7 +6,7 @@
         <file>${FULL_LOGGING_PATH}</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <maxHistory>5</maxHistory>
-            <fileNamePattern>./arch3_old/arch3_test.%d{YYYY-MM-dd}.%i.log.zip</fileNamePattern>
+            <fileNamePattern>${FULL_LOGGING_PATH}.%d{YYYY-MM-dd}.%i.zip</fileNamePattern>
             <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                 <maxFileSize>2GB</maxFileSize>
             </timeBasedFileNamingAndTriggeringPolicy>

--- a/pancancer-common/pom.xml
+++ b/pancancer-common/pom.xml
@@ -112,6 +112,15 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <CONSONANCE_LOG_FILE>./test.log</CONSONANCE_LOG_FILE>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/pancancer-common/pom.xml
+++ b/pancancer-common/pom.xml
@@ -103,6 +103,15 @@
                     <target>1.7</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <CONSONANCE_LOG_FILE>./test.log</CONSONANCE_LOG_FILE>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/pancancer-common/src/main/resources/logback.xml
+++ b/pancancer-common/src/main/resources/logback.xml
@@ -6,7 +6,7 @@
         <file>${FULL_LOGGING_PATH}</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <maxHistory>7</maxHistory>
-            <fileNamePattern>./arch3.%d{YYYY-MM-dd}.%i.log.zip</fileNamePattern>
+            <fileNamePattern>${FULL_LOGGING_PATH}.%d{YYYY-MM-dd}.%i.zip</fileNamePattern>
             <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                 <maxFileSize>2GB</maxFileSize>
             </timeBasedFileNamingAndTriggeringPolicy>

--- a/pancancer-common/src/main/resources/logback.xml
+++ b/pancancer-common/src/main/resources/logback.xml
@@ -3,7 +3,7 @@
     <appender name="FILE_APPENDER" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <!-- encoders are assigned the type
         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
-        <file>./arch3.log</file>
+        <file>/home/${USER}/arch3/logs/arch3.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <maxHistory>7</maxHistory>
             <fileNamePattern>./arch3.%d{YYYY-MM-dd}.%i.log.zip</fileNamePattern>

--- a/pancancer-common/src/main/resources/logback.xml
+++ b/pancancer-common/src/main/resources/logback.xml
@@ -3,10 +3,10 @@
     <appender name="FILE_APPENDER" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <!-- encoders are assigned the type
         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
-        <file>${FULL_LOGGING_PATH}</file>
+        <file>${CONSONANCE_LOG_FILE}</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <maxHistory>7</maxHistory>
-            <fileNamePattern>${FULL_LOGGING_PATH}.%d{YYYY-MM-dd}.%i.zip</fileNamePattern>
+            <fileNamePattern>${CONSONANCE_LOG_FILE}.%d{YYYY-MM-dd}.%i.zip</fileNamePattern>
             <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                 <maxFileSize>2GB</maxFileSize>
             </timeBasedFileNamingAndTriggeringPolicy>

--- a/pancancer-common/src/main/resources/logback.xml
+++ b/pancancer-common/src/main/resources/logback.xml
@@ -3,7 +3,7 @@
     <appender name="FILE_APPENDER" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <!-- encoders are assigned the type
         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
-        <file>/home/${USER}/arch3/logs/arch3.log</file>
+        <file>${FULL_LOGGING_PATH}</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <maxHistory>7</maxHistory>
             <fileNamePattern>./arch3.%d{YYYY-MM-dd}.%i.log.zip</fileNamePattern>

--- a/pancancer-reporting/pom.xml
+++ b/pancancer-reporting/pom.xml
@@ -192,7 +192,15 @@
                     <target>1.7</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <CONSONANCE_LOG_FILE>./test.log</CONSONANCE_LOG_FILE>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
-
 </project>

--- a/pancancer-reporting/pom.xml
+++ b/pancancer-reporting/pom.xml
@@ -201,6 +201,15 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <CONSONANCE_LOG_FILE>./test.log</CONSONANCE_LOG_FILE>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -477,9 +477,6 @@
                     </execution>
                 </executions>
             </plugin>
-
         </plugins>
     </build>
-
-
 </project>


### PR DESCRIPTION
Log to a file at `${CONSONANCE_LOG_FILE}` which will be defined outside the application, instead of `./arch3.log` which is relative to where ever the user is when they call an arch3/consonance command.
