### PR TITLE
Add retry of initial establishment of queues and connections

### DIFF
--- a/consonance-arch/src/main/java/io/consonance/arch/jobGenerator/JobGenerator.java
+++ b/consonance-arch/src/main/java/io/consonance/arch/jobGenerator/JobGenerator.java
@@ -22,7 +22,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeoutException;
 
 /**
  * Submits orders into the queue system.
@@ -94,7 +93,7 @@ public class JobGenerator extends Base {
         try {
             // SETUP QUEUE
             this.jchannel = CommonServerTestUtilities.setupQueue(settings, queueName + "_orders");
-        } catch (TimeoutException ex) {
+        } catch (InterruptedException ex) {
             throw new RuntimeException(ex);
         }
         if (options.has(iniDirSpec)) {

--- a/consonance-arch/src/main/java/io/consonance/arch/worker/WorkerHeartbeat.java
+++ b/consonance-arch/src/main/java/io/consonance/arch/worker/WorkerHeartbeat.java
@@ -43,15 +43,9 @@ public class WorkerHeartbeat implements Runnable {
     @Override
     public void run() {
 
-        Channel reportingChannel = null;
+        Channel reportingChannel;
         try {
-            try {
-                reportingChannel = CommonServerTestUtilities.setupExchange(settings, this.queueName);
-            } catch (IOException | TimeoutException | AlreadyClosedException e) {
-                LOG.error("Exception caught! Queue channel could not be opened, waiting. Exception is: " + e.getMessage(), e);
-                // retry after a minute, do not die simply because the launcher is unavailable, it may come back
-                Thread.sleep(Base.ONE_MINUTE_IN_MILLISECONDS);
-            }
+            reportingChannel = CommonServerTestUtilities.setupExchange(settings, this.queueName);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             LOG.info("Caught interrupt signal, heartbeat shutting down.", e);

--- a/consonance-arch/src/test/java/io/consonance/arch/test/TestCoordinator.java
+++ b/consonance-arch/src/test/java/io/consonance/arch/test/TestCoordinator.java
@@ -70,7 +70,7 @@ public class TestCoordinator {
     private static StringBuffer outBuffer = new StringBuffer();
 
     @Before
-    public void setup() throws IOException, TimeoutException {
+    public void setup() throws IOException, TimeoutException, InterruptedException {
         MockitoAnnotations.initMocks(this);
 
         outBuffer = new StringBuffer();

--- a/consonance-reporting/src/main/java/io/consonance/arch/reporting/Arch3ReportImpl.java
+++ b/consonance-reporting/src/main/java/io/consonance/arch/reporting/Arch3ReportImpl.java
@@ -134,7 +134,7 @@ public class Arch3ReportImpl implements ReportAPI {
 
                 return cache;
 
-            } catch (IOException | ShutdownSignalException | InterruptedException | TimeoutException | ConsumerCancelledException ex) {
+            } catch (IOException | ShutdownSignalException | InterruptedException | ConsumerCancelledException ex) {
                 throw new RuntimeException(ex);
             } finally {
                 try {

--- a/consonance-server-common/src/test/java/io/consonance/arch/utils/UtilitiesIT.java
+++ b/consonance-server-common/src/test/java/io/consonance/arch/utils/UtilitiesIT.java
@@ -60,7 +60,7 @@ public class UtilitiesIT {
      * @throws java.io.IOException
      */
     @Test
-    public void testSetupQueue() throws IOException, TimeoutException {
+    public void testSetupQueue() throws IOException, TimeoutException, InterruptedException {
         Channel result = CommonServerTestUtilities.setupQueue(getSettings(), "testing_queue");
         assertTrue("could not open channel", result.isOpen());
         result.close();
@@ -72,7 +72,7 @@ public class UtilitiesIT {
      * @throws java.io.IOException
      */
     @Test
-    public void testSetupMultiQueue() throws IOException, TimeoutException {
+    public void testSetupMultiQueue() throws IOException, TimeoutException, InterruptedException {
         Channel result = CommonServerTestUtilities.setupExchange(getSettings(), "testing_queue");
         assertTrue("could not open channel", result.isOpen());
         result.close();

--- a/consonance-webservice/src/main/java/io/consonance/webservice/resources/OrderResource.java
+++ b/consonance-webservice/src/main/java/io/consonance/webservice/resources/OrderResource.java
@@ -56,7 +56,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 /**
@@ -149,7 +148,7 @@ public class OrderResource {
         if (jchannel == null || !jchannel.isOpen()) {
             try {
                 this.jchannel = CommonServerTestUtilities.setupQueue(settings, queueName + "_orders");
-            } catch (IOException | TimeoutException e) {
+            } catch (InterruptedException ex) {
                 throw new InternalServerErrorException();
             }
         }


### PR DESCRIPTION
This is separate from auto-recovery which is used while a connection is
live. In phase 2 we should experiment with a newer rabbitmq-java client,
see https://github.com/rabbitmq/rabbitmq-java-client/issues/81 for a
useful config parameter
